### PR TITLE
Undo amount string formatting and add start block switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ These are workflow scripts for Github productivity.
 * **rr** - Request Review
 * **rrr** - Re-request Review
 * **fork** - Fork and clone
-* **web3** - Evaluate web3
 
 These are Ethereum utility scripts for TrustToken.
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The eval context also can reference TrueUSD and its Controller objects.
 
 ## requestMints
 
-    requestMints [-a] [-g]
+    requestMints [-a] [-g] [-s start_block]
 
 The script lists recent MintOperationEvent events in the TrueUSD Controller.
 The events are copied into your pasteboard.
@@ -151,7 +151,7 @@ Formats the event data for pasting into a spreadsheet.
 
 ## finalizeMints
 
-    finalizeMints [-a] [-g]
+    finalizeMints [-a] [-g] [-s start_block]
 
 The script lists recent Mint events in TrueUSD.
 The events are copied into your pasteboard.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ Instead of listing recent events, list all events.
 ### -g
 Formats the event data for pasting into a spreadsheet.
 
+### -s start\_block
+Specify starting block
+
 ## finalizeMints
 
     finalizeMints [-a] [-g] [-s start_block]
@@ -160,6 +163,9 @@ Instead of listing recent events, list all events.
 
 ### -g
 Formats the event data for pasting into a spreadsheet.
+
+### -s start\_block
+Specify starting block
 
 # Configuration
 ## Text Editor

--- a/bin/finalizeMints
+++ b/bin/finalizeMints
@@ -15,7 +15,7 @@ else
     PRIOR=5198576 
 fi
 
-while getopts 'asg' flag; do
+while getopts 'as:g' flag; do
     case "${flag}" in
         a) PRIOR=5198576 ;;
         s) PRIOR="${OPTARG}" ;;

--- a/bin/js/fetchMintEvents.js
+++ b/bin/js/fetchMintEvents.js
@@ -22,7 +22,7 @@ function formatRowSheet({ event, transaction }) {
     const decodedTransaction = abiDecoder.decodeMethod(transaction.input);
     const mintIndex = decodedTransaction.params[0].value;
     const amount = (event.returnValues.amount / 10 ** 18).toFixed(2);
-    return '=SPLIT("' + event.transactionHash + ',' + event.returnValues.to + ',\'' + amount + ',' + event.blockNumber + ',' + mintIndex + '", ",")';
+    return '=SPLIT("' + event.transactionHash + ',' + event.returnValues.to + ',' + amount + ',' + event.blockNumber + ',' + mintIndex + '", ",")';
 }
 
 function formatRowEvent({ event, transaction }) {

--- a/bin/requestMints
+++ b/bin/requestMints
@@ -15,7 +15,7 @@ else
     PRIOR=5198576 
 fi
 
-while getopts 'asg' flag; do
+while getopts 'as:g' flag; do
     case "${flag}" in
         a) PRIOR=6718586 ;;
         s) PRIOR="${OPTARG}" ;;


### PR DESCRIPTION

#### Changes
This adds the start block option.
This also fixes and issue Tyler noticed that finalize mint amounts weren't equal because they were strings.
Reviewers @terryli0095