### PR TITLE
Format BlockNumber in Decimal

### DIFF
--- a/bin/js/fetchRequestMintEvents.js
+++ b/bin/js/fetchRequestMintEvents.js
@@ -48,6 +48,7 @@ req.onreadystatechange = () => {
     for (let result of results) {
       const event = {
         ...result,
+        blockNumber: web3.utils.hexToNumberString(result.blockNumber),
         returnValues: {
           opIndex: web3.utils.hexToNumberString(result.data.slice(0, 66)),
           to: '0x' + result.topics[1].slice(26),


### PR DESCRIPTION

#### Changes
Web3 formatted blockNumber in decimal.
This fixes a regression in the formatting for spreadsheet tracking.
Reviewers @terryli0095