### PR TITLE
Use __dirname for providerUrl config

### DIFF
--- a/bin/js/web3.js
+++ b/bin/js/web3.js
@@ -3,7 +3,6 @@
 // web3 = require('./web3.js');
 
 const fs = require('fs');
-const path = require('path');
 const Web3 = require('web3');
 
 const defaultProviderUrl = 'https://mainnet.infura.io';

--- a/bin/js/web3.js
+++ b/bin/js/web3.js
@@ -3,13 +3,15 @@
 // web3 = require('./web3.js');
 
 const fs = require('fs');
+const path = require('path');
 const Web3 = require('web3');
 
 const defaultProviderUrl = 'https://mainnet.infura.io';
 
 let customProviderUrl;
 try {
-  customProviderUrl = fs.readFileSync('./config/ethrpc', 'utf8');
+  const configPath = __dirname + '/../../config/ethrpc';
+  customProviderUrl = fs.readFileSync(configPath, 'utf8');
 } catch (e) {}
 
 const providerUrl = customProviderUrl || defaultProviderUrl;


### PR DESCRIPTION

#### Changes
I discovered the path was not relative to node but to the current directory.
`__dirname` appears to be the js analog of `$(dirname $0)`.
Reviewers @terryli0095