### PR TITLE
Show Provider Url Errors

### DIFF
--- a/bin/js/providerUrl.js
+++ b/bin/js/providerUrl.js
@@ -1,9 +1,16 @@
+const fs = require('fs');
+
 const defaultProviderUrl = 'https://mainnet.infura.io';
 let customProviderUrl;
 try {
   const configPath = __dirname + '/../../config/ethrpc';
   customProviderUrl = fs.readFileSync(configPath, 'utf8');
-} catch (e) {}
+} catch (e) {
+  if (e.code != 'ENOENT') {
+    console.error(e)
+    console.log('Using', defaultProviderUrl);
+  }
+}
 
 const providerUrl = customProviderUrl || defaultProviderUrl;
 

--- a/bin/js/web3.js
+++ b/bin/js/web3.js
@@ -2,7 +2,6 @@
 // Include it with:
 // web3 = require('./web3.js');
 
-const fs = require('fs');
 const Web3 = require('web3');
 const providerUrl = require('./providerUrl.js');
 


### PR DESCRIPTION
#### Changes
We would like to show errors reading the provider URL other than ENOENT, which indicates they have not configured their RPC URL.
This also fixes an error introduced when this file was separated from web3.js.
Reviewers @terryli0095 