### PR TITLE
refundPool -a: print as you go

### DIFF
--- a/bin/js/fullRefundPool.js
+++ b/bin/js/fullRefundPool.js
@@ -45,7 +45,7 @@ async function run() {
         i -= BATCH_SIZE;
         return;
       }
-      printLines({ start: i, end: Math.min(i + BATCH_SIZE - 1, len) });
+      printLines({ start: i, end: Math.min(i + BATCH_SIZE - 1, len - 1) });
     }).catch(async function(error) {
       if (!error.message.startsWith("BatchRequest error")) {
         console.error(error);

--- a/bin/js/fullRefundPool.js
+++ b/bin/js/fullRefundPool.js
@@ -8,11 +8,28 @@ function printLine({ start, end, value }) {
   console.log(`${start} - ${end}:\t${value}\t[${end - start + 1}]`);
 }
 
+let lastPrinted = 0;
+let arr = [];
+function printLines({ start, end }) {
+  let value = arr[lastPrinted];
+  for (let i = start; i < end; i++) {
+    if (value != arr[i]) {
+      printLine({
+        start: lastPrinted,
+        end: i - 1,
+        value
+      });
+      start = i;
+      lastPrinted = i; 
+      value = arr[i];
+    }
+  }
+}
+
 const BATCH_SIZE = 2500;
 
 async function run() {
   let len = await TrueUSD.methods.remainingGasRefundPool().call();
-  let arr = [];
   for (let i = 0; i < len; i += BATCH_SIZE) {
     const batch = new web3.eth.BatchRequest();
     for (let j = i; j < len && j < i + BATCH_SIZE; j++) {
@@ -26,7 +43,14 @@ async function run() {
         arr[j] = result;
       }));
     }
-    await batch.execute().catch(async function(error) {
+    await batch.execute().then((results) => {
+      if (arr[i] == null) {
+        // retry
+        i -= BATCH_SIZE;
+        return;
+      }
+      printLines({ start: i, end: Math.min(i + BATCH_SIZE - 1, len) });
+    }).catch(async function(error) {
       if (!error.message.startsWith("BatchRequest error")) {
         console.error(error);
       }
@@ -35,25 +59,10 @@ async function run() {
       i -= BATCH_SIZE;
     });
   }
-  let start = 0;
-  let end = 0;
-  let value = arr[0];
-  for (let i = 1; i < len; i++) {
-    if (value != arr[i]) {
-      printLine({
-        start,
-        end,
-        value
-      });
-      start = i;
-      value = arr[i];
-    }
-    end = i;
-  }
   printLine({
-    start,
+    start: lastPrinted,
     end: len - 1,
-    value
+    value: arr[lastPrinted]
   });
 }
 

--- a/bin/js/fullRefundPool.js
+++ b/bin/js/fullRefundPool.js
@@ -4,21 +4,20 @@ const TrueUSDAddress = '0x0000000000085d4780B73119b644AE5ecd22b376';
 const TrueUSDAbi = require('../abi/trueUsdAbi.json')
 const TrueUSD = new web3.eth.Contract(TrueUSDAbi, TrueUSDAddress)
 
-function printLine({ start, end, value }) {
-  console.log(`${start} - ${end}:\t${value}\t[${end - start + 1}]`);
+let arr = [];
+function printLine({ start, end }) {
+  console.log(`${start} - ${end}:\t${arr[start]}\t[${end - start + 1}]`);
 }
 
-let lastPrinted = 0;
-let arr = [];
+let nextPrintStart = 0;
 function printLines({ start, end }) {
   for (let i = start; i < end; i++) {
-    if (arr[lastPrinted] != arr[i]) {
+    if (arr[nextPrintStart] != arr[i]) {
       printLine({
-        start: lastPrinted,
+        start: nextPrintStart,
         end: i - 1,
-        value: arr[lastPrinted],
       });
-      lastPrinted = i; 
+      nextPrintStart = i;
     }
   }
 }
@@ -57,9 +56,8 @@ async function run() {
     });
   }
   printLine({
-    start: lastPrinted,
+    start: nextPrintStart,
     end: len - 1,
-    value: arr[lastPrinted]
   });
 }
 

--- a/bin/js/fullRefundPool.js
+++ b/bin/js/fullRefundPool.js
@@ -45,7 +45,7 @@ async function run() {
         i -= BATCH_SIZE;
         return;
       }
-      printLines({ start: i, end: Math.min(i + BATCH_SIZE - 1, len - 1) });
+      printLines({ start: i, end: Math.min(i + BATCH_SIZE, len) - 1 });
     }).catch(async function(error) {
       if (!error.message.startsWith("BatchRequest error")) {
         console.error(error);

--- a/bin/js/fullRefundPool.js
+++ b/bin/js/fullRefundPool.js
@@ -11,17 +11,14 @@ function printLine({ start, end, value }) {
 let lastPrinted = 0;
 let arr = [];
 function printLines({ start, end }) {
-  let value = arr[lastPrinted];
   for (let i = start; i < end; i++) {
-    if (value != arr[i]) {
+    if (arr[lastPrinted] != arr[i]) {
       printLine({
         start: lastPrinted,
         end: i - 1,
-        value
+        value: arr[lastPrinted],
       });
-      start = i;
       lastPrinted = i; 
-      value = arr[i];
     }
   }
 }


### PR DESCRIPTION

#### Changes
With this change, `refundPool -a` will print as it gets results instead of waiting until the end.
I also add retry logic for null results, which still seem to happen with a batch size of 2500.
Reviewers @terryli0095